### PR TITLE
Show the thumbnail icons on mouseover instead of all at once

### DIFF
--- a/data/newtabicons-content.js
+++ b/data/newtabicons-content.js
@@ -11,10 +11,10 @@ let thumbnails = window.document.getElementsByClassName('newtab-thumbnail');
 
 for (let i = 0; i < thumbnails.length; ++i) {
   let thumb = thumbnails[i];
-  let newPreview = 'url("' + self.options["thumbs"][i] + '")';
+  let newPreview = 'url("' + self.options.thumbs[i] + '")';
   let oldPreview = thumb.style.backgroundImage;
 
-  if (self.options["showAlways"]) {
+  if (self.options.showAlways) {
     thumb.style.backgroundImage = newPreview;
   } else {
     thumb.addEventListener("mouseover", function(el, image) {

--- a/lib/newtabicons.js
+++ b/lib/newtabicons.js
@@ -19,7 +19,6 @@ var self = require('self');
 var tabs = require('tabs');
 var winutils = require('window/utils');
 
-var tracker = null;
 var running = false;
 
 etherpad.setDefaults([
@@ -35,7 +34,7 @@ var tabOpen = function (tab) {
       tab.attach({
         contentScriptFile: self.data.url("newtabicons-content.js"),
         contentScriptOptions: { "thumbs" : etherpad.getRandomItems(9),
-                                "showAlways" : prefs.prefs.newtabicons == 0 }
+                                "showAlways" : prefs.prefs.newtabicons === 1 }
       });
     }
   });
@@ -66,7 +65,7 @@ var stop = function () {
 };
 
 var listener = function (prefName) {
-  if (prefs.prefs.newtabicons != 2) {
+  if (prefs.prefs.newtabicons) {
     run();
   } else {
     stop();

--- a/package.json
+++ b/package.json
@@ -19,19 +19,19 @@
       "title": "Newtab icons",
       "description": "Add better icons for the new tab page.",
       "type": "menulist",
-      "value": 0,
+      "value": 1,
       "options": [
         {
           "value": "0",
-          "label": "On (always)"
+          "label": "Off"
         },
         {
           "value": "1",
-          "label": "On (hover only)"
+          "label": "Always On"
         },
         {
           "value": "2",
-          "label": "Off"
+          "label": "Hover to Show"
         }
       ]
     }


### PR DESCRIPTION
I'd like to propose loading the thumbnail gifs on mouse over instead of all at once because:
a) less overwhelming
b) surprise!
c) you can still see the original thumbnail previews

Maybe do this if a pref is set or something..
