### PR TITLE
Added Skytrain protoype GIF.

### DIFF
--- a/thumbnail-gifs.txt
+++ b/thumbnail-gifs.txt
@@ -840,3 +840,5 @@ http://media.boingboing.net/wp-content/uploads/2013/10/chain.gif
 http://i.imgur.com/lSjkmNj.gif
 http://i.imgur.com/0AZnj2E.gif
 http://gifmansion.com/GM/uploads/2013/06/Trackmania.gif
+# Shytrain prototype GIF
+http://31.media.tumblr.com/4dbe147750e3e2934672e85ba19f0778/tumblr_mt6i57gmHW1sfo4yxo1_400.gif


### PR DESCRIPTION
Source http://vancouverisawesome.com/2013/10/23/gif-skytrain-prototype-from-1982/
