### PR TITLE
about:nope improvement

### DIFF
--- a/lib/nope.js
+++ b/lib/nope.js
@@ -20,8 +20,6 @@ var nope_override = function nope_override(request, response) {
     'body {' +
     'width: 100%;' +
     'height: 100%;' +
-    'background-size:cover;' +
-    'background-repeat: no-repeat;' +
     'background-image:url("' + self.data.url('nopetopus.gif') + '");' +
     '}</style></head><body>&nbsp</body></html>');
 };


### PR DESCRIPTION
Fix for turning about:nope on/off. 
Changed background size as well as repeat to auto. This results in many little nopetopi. If only one nopetopus is desired, background-size should be changed to "contain" to make it look better in a resized window.
