### PR TITLE
Issue 86: Don't let too many Mario coin sounds play at once.

### DIFF
--- a/lib/mario.js
+++ b/lib/mario.js
@@ -10,12 +10,19 @@
 
 let prefs = require('sdk/simple-prefs');
 let self = require('sdk/self');
+const { setTimeout } = require('sdk/timers');
+
 const { Cc, Cu, Cr, Ci } = require('chrome');
 
 const MARIO_PREF = 'mario';
 const COIN_URL = self.data.url('coin.mp3');
 const INVINCIBLE_URL = self.data.url('invincible.mp3');
 const PAINT_FLASHING_PREF = "nglayout.debug.paint_flashing";
+// Things like sync can cause Firefox to add many, many bookmarks
+// all at once. This can cause many coins to play simultaniously
+// which sounds horrible and annoying as opposed to whimsical and
+// hilarious.
+const COIN_REPLAY_TIME = 5000; // milliseconds
 
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
@@ -36,6 +43,7 @@ let pageWorker = require('sdk/page-worker').Page({
 });
 
 var ready = false;
+var isPastCoinReplayTime = true;
 
 pageWorker.port.on("loaded", function() {
   ready = true;
@@ -45,10 +53,16 @@ let coinObserver = {
   onBeginUpdateBatch: function() {},
   onEndUpdateBatch: function() {},
   onItemAdded: function(id, folder, index) {
-    if (ready) {
+    if (ready && isPastCoinReplayTime) {
       pageWorker.port.emit("play-once", {
         url: COIN_URL
       });
+
+      isPastCoinReplayTime = false;
+
+      setTimeout(() => {
+        isPastCoinReplayTime = true;
+      }, COIN_REPLAY_TIME);
     }
   },
   onItemRemoved: function(id, folder, index) {},


### PR DESCRIPTION
This change adds a 5 second delay before another Mario coin
can be played. This is for situations where some background
task can add many bookmarks all at once (like Sync), which
without this patch causes many coin sounds to play all at
once which is quite unpleasant.
