### PR TITLE
Remove obsolete 64-bit line

### DIFF
--- a/urlbar-sayings.txt
+++ b/urlbar-sayings.txt
@@ -106,7 +106,6 @@ Never gonna give you up, never gonna let you down
 If the apocolypse comes, beep me
 http://quotes.burntelectrons.org
 http://mozillamemes.tumblr.com
-I can't believe Firefox isn't 64-bit yet! I'm leaving you for Chrome!
 Duke (duke duke) Duke of URL (duke duke) Duke of URL (duke duke) Duke of URRRRLLL!
 Web surfing is hard, let's go shopping. Screw that, shopping is hard, let's do matrix multiplication!
 swirly donut? at least it's not the dreaded read admiral.


### PR DESCRIPTION
Chrome does have 64-bit Windows builds now (and so do we I think).
